### PR TITLE
Add HostID to server stream messages

### DIFF
--- a/websockets/subscribe.go
+++ b/websockets/subscribe.go
@@ -36,6 +36,7 @@ type ServerStreamMsg struct {
 	Status     string `json:"server_status"`
 	LoadBase   int    `json:"load_base"`
 	LoadFactor int    `json:"load_factor"`
+	HostID     string `json:"hostid"`
 }
 
 // Map message types to the appropriate data structure


### PR DESCRIPTION
Often one connects to a rippled which is actually a cluster, not a single server.  It can be helpful to log specifically which server in the cluster is being used.  This can be learned from "hostid" in the JSON from server_info.  Not sure which other fields are worth adding here.

https://ripple.com/build/rippled-apis/#server-info