### PR TITLE
Sometimes subscribe result contains "offers"

### DIFF
--- a/websockets/subscribe.go
+++ b/websockets/subscribe.go
@@ -57,8 +57,11 @@ type SubscribeResult struct {
 	// Contains one or both of these, depending what streams were subscribed
 	*LedgerStreamMsg
 	*ServerStreamMsg
+	// Contains "bids" and "asks" when "both" is true.
 	Asks []data.OrderBookOffer
 	Bids []data.OrderBookOffer
+	// Contains "offers" when "both" is false.
+	Offers []data.OrderBookOffer
 }
 
 // Wrapper to stop recursive unmarshalling


### PR DESCRIPTION
I've noticed that an offer book subscription will contain "bids" and "asks" when the "both":true option is specified.  When "both":false, it contains "offers" instead.

This PR adds Offers to SubscribeResult.  Which gives the JSON unmarshaller someplace to put "offers".  What do you think?

It could be a long road to keep fine-tuning these type definitions to exactly match up with what rippled expects and returns.  I wonder whether it makes sense to have a more generic method to submit any command and get back any result?  That is, unmarshal into interface{} to get everything that ripple returns.  And allow applications more control over the command that is sent.  For example an app could construct a BookOffersCommand with a different limit than hardcoded in remote.BookOffers().  

I'm not sure exactly what that more generic command interface would look like.  Any thoughts?