### PR TITLE
account_tx command: support min and max ledger

### DIFF
--- a/websockets/commands.go
+++ b/websockets/commands.go
@@ -76,12 +76,12 @@ type AccountTxResult struct {
 	Transactions data.TransactionSlice  `json:"transactions,omitempty"`
 }
 
-func newAccountTxCommand(account data.Account, pageSize int, marker map[string]interface{}) *AccountTxCommand {
+func newAccountTxCommand(account data.Account, pageSize int, marker map[string]interface{}, minLedger, maxLedger int64) *AccountTxCommand {
 	return &AccountTxCommand{
 		Command:   newCommand("account_tx"),
 		Account:   account,
-		MinLedger: -1,
-		MaxLedger: -1,
+		MinLedger: minLedger,
+		MaxLedger: maxLedger,
 		Limit:     pageSize,
 		Marker:    marker,
 	}


### PR DESCRIPTION
I had a need to call account_tx for a specific ledger.  This patch adds minLedger and maxLedger parameters to remote.AccountTx and passes them down the stack.

What do you think?