### PR TITLE
Fix issues in Balances() by creating type BalanceMap and return it instead of BalanceSlice.

### DIFF
--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -221,8 +221,8 @@ func newBundle(value interface{}, flag Flag) (*bundle, error) {
 	case data.Balance:
 		return &bundle{
 			color:  balanceStyle,
-			format: "Balance: %-34s  Currency: %s Balance: %20s Change: %20s",
-			values: []interface{}{v.Account, v.Currency, v.Balance, v.Change},
+			format: "CounterParty: %-34s  Currency: %s Balance: %20s Change: %20s",
+			values: []interface{}{v.CounterParty, v.Currency, v.Balance, v.Change},
 			flag:   flag,
 		}, nil
 	case data.Path:

--- a/tools/explain/explain.go
+++ b/tools/explain/explain.go
@@ -78,10 +78,13 @@ func explain(txm *data.TransactionWithMetaData, flag terminal.Flag) {
 		}
 	}
 	if !*balances {
-		balances, err := txm.Balances()
+		balanceMap, err := txm.Balances()
 		checkErr(err)
-		for _, balance := range balances {
-			terminal.Println(balance, flag|terminal.Indent)
+		for account, balances := range balanceMap {
+			terminal.Println(account, flag|terminal.Indent)
+			for _, balance := range *balances {
+				terminal.Println(balance, flag|terminal.DoubleIndent)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This is inspired by https://ripple.com/dev-blog/calculating-balance-changes-for-transaction/

A notably difference with the result of ripple-lib-transactionparser is
that transaction fee is not included in BalanceMap.

This also fixes two existing issues:

1. The account of a created ripple state can be different from the
   account who issued the transaction. For example:
   https://xrpcharts.ripple.com/#/transactions/2E6D0C90CF0C6A12B45ABA272512C1BC2D228F5412AA599E4C8CB22DF3487706

2. The low account should have balance, while the high account should
   have negated balance, as explained in https://ripple.com/build/ledger-format/#ripplestate