### PR TITLE
Loosen os.Args check in book tool

### DIFF
--- a/tools/book/book.go
+++ b/tools/book/book.go
@@ -38,7 +38,7 @@ func checkErr(err error) {
 }
 
 func main() {
-	if len(os.Args) != 3 {
+	if len(os.Args) < 3 {
 		showUsage()
 	}
 	flag.CommandLine.Parse(os.Args[3:])


### PR DESCRIPTION
This is necessary for setting the host via flags. If you pass in a host flag the exact equality check will fail.