### PR TITLE
Update memo struct to use and additional structure as memo item instead of embedded structure

### DIFF
--- a/data/memo.go
+++ b/data/memo.go
@@ -1,11 +1,13 @@
 package data
 
+type MemoItem struct {
+	MemoType   VariableLength
+	MemoData   VariableLength
+	MemoFormat VariableLength
+}
+
 type Memo struct {
-	Memo struct {
-		MemoType   VariableLength
-		MemoData   VariableLength
-		MemoFormat VariableLength
-	}
+	Memo MemoItem
 }
 
 type Memos []Memo


### PR DESCRIPTION
With the previous embedded struct, it was convenient if you read the transaction, but if not convenient if you create a transaction with the memo.

Previous ways of creating a memo:
```go

type MyMemoItem struct {
	MemoType   data.VariableLength
	MemoData   data.VariableLength
	MemoFormat data.VariableLength
}

func main() {
	// example 1
	memos := make(data.Memos, 1)
	memos[0].Memo.MemoType = data.VariableLength("type")
	memos[0].Memo.MemoData = data.VariableLength("data")
	memos[0].Memo.MemoFormat = data.VariableLength("format")

	// example 2
	memos = []data.Memo{
		{
			Memo: struct {
				MemoType   data.VariableLength
				MemoData   data.VariableLength
				MemoFormat data.VariableLength
			}{
				MemoType:   data.VariableLength("type"),
				MemoData:   data.VariableLength("data"),
				MemoFormat: data.VariableLength("format"),
			},
		},
	}

	// example 3
	memos = []data.Memo{
		{
			Memo: MyMemoItem{
				MemoType:   data.VariableLength("type"),
				MemoData:   data.VariableLength("data"),
				MemoFormat: data.VariableLength("format"),
			},
		},
	}
}
```

The proposed changes are not breaking for `example 1` and `example 2`, but breaking for `example 3` which is rare in terms of usage in general. Anyway IMHO, better practice to have a common `MemoItem`.

```go
memos = []data.Memo{
		{
			Memo: data.MemoItem{
				MemoType:   data.VariableLength("type"),
				MemoData:   data.VariableLength("data"),
				MemoFormat: data.VariableLength("format"),
			},
		},
	}
```