### PR TITLE
Add `Exception` to `CommandError` for the better error message.

### DIFF
--- a/websockets/commands.go
+++ b/websockets/commands.go
@@ -16,9 +16,10 @@ type Syncer interface {
 }
 
 type CommandError struct {
-	Name    string `json:"error"`
-	Code    int    `json:"error_code"`
-	Message string `json:"error_message"`
+	Name      string `json:"error"`
+	Code      int    `json:"error_code"`
+	Message   string `json:"error_message"`
+	Exception string `json:"error_exception"`
 }
 
 type Command struct {
@@ -48,7 +49,7 @@ func (c *Command) IncrementId() {
 }
 
 func (e *CommandError) Error() string {
-	return fmt.Sprintf("%s %d %s", e.Name, e.Code, e.Message)
+	return fmt.Sprintf("%s %d %s %s", e.Name, e.Code, e.Message, e.Exception)
 }
 
 func newCommand(command string) *Command {


### PR DESCRIPTION
It was found in the responses from the `testnet` that the response contains an additional attribute with the detailed error.

The PR contains changes for the error message improvements. 

You can try that code snippet (with updated code):
```go
func main() {
	host := "wss://s.altnet.rippletest.net:51233/"
	remote, err := websockets.NewRemote(host)
	panicIfErr(err)
	amount, err := data.NewAmount("100000") // 0.1 XRP tokens
	tx := data.Payment{
		Amount: *amount,
		TxBase: data.TxBase{
			TransactionType: data.PAYMENT,
		},
	}
	// submit the transaction
	_, err = remote.Submit(&tx)
	fmt.Printf("%s\n", err)
}

func panicIfErr(err error) {
	if err != nil {
		panic(err)
	}
}
```

The output:
```
invalidTransaction 0  gFID: uncommon type out of range 0
```

Raw response.
```json
{"error":"invalidTransaction","error_exception":"gFID: uncommon type out of range 0","id":1,"request":{"command":"submit","id":1,"tx_blob":"12000024000000006140000000000186A06880000000000000008114000000000000000000000000000000000000000083140000000000000000000000000000000000000000"},"status":"error","type":"response"}
```
----


The output if you run it from the master:
```
invalidTransaction 0 
```

