### PR TITLE
feature: Account parsing helper functions to decode HEX to account object, and account from hash256

### DIFF
--- a/data/hash.go
+++ b/data/hash.go
@@ -82,6 +82,31 @@ func (h *Hash160) Currency() *Currency {
 	return &c
 }
 
+// NewAccountFromHext transforms a hex string into an Account
+// e.g. C35B55AA096BA6D87A6E6C965A6534150DC56E5E to rJoxBSzpXhPtAuqFmqxQtGKjA13jUJWthE
+// Input has to by a string of length 40
+// Typical usage is for the nft token id decode: https://xrpl.org/nftoken.html#nftokenid
+func NewAccountFromHex(s string) (*Account, error) {
+	if len(s) != 40 {
+		return nil, fmt.Errorf("NewAccountFromHex: Wrong length %s (expecting len of 40)", s)
+	}
+	var a Account
+	_, err := hex.Decode(a[:], []byte(s))
+	if err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+func NewAccountFromHash256(h Hash256) (*Account, error) {
+	if len(h) != 20 {
+		return nil, fmt.Errorf("NewAccountFromHash256: Wrong length %X (expecting len of 20)", h)
+	}
+	var a Account
+	copy(a[:], h[:])
+	return &a, nil
+}
+
 // Accepts either a hex string or a byte slice of length 32
 func NewHash256(value interface{}) (*Hash256, error) {
 	var h Hash256


### PR DESCRIPTION
Certain input from the ledger or manipulations of ledger data require to be able to decode the hex encoding of accounts, as well the use of the hash256 of the account to an account object.
The 2 provided functions have been created as handy helper functions to do this centralized in 1 step.