### PR TITLE
feature: AMM implementation

### DIFF
--- a/data/amm.go
+++ b/data/amm.go
@@ -1,0 +1,32 @@
+package data
+
+import "fmt"
+
+var txAmmAcceptedMap = map[TransactionType]bool{AMM_DEPOSIT: true, AMM_WITHDRAW: true, AMM_CREATE: true, AMM_VOTE: true, AMM_BID: true, PAYMENT: true}
+
+func (txm *TransactionWithMetaData) AMM() (*AMM, error) {
+	if !txAmmAcceptedMap[txm.GetTransactionType()] {
+		return nil, nil
+	}
+	for _, nodeAffect := range txm.MetaData.AffectedNodes {
+		switch {
+		case nodeAffect.CreatedNode != nil && nodeAffect.CreatedNode.LedgerEntryType == AMMROOT:
+			ammParsed, ok := nodeAffect.CreatedNode.NewFields.(*AMM)
+			if ok {
+				if nodeAffect.CreatedNode.LedgerIndex != nil {
+					ammParsed.LedgerIndex = nodeAffect.CreatedNode.LedgerIndex
+				}
+				return ammParsed, nil
+			}
+		case nodeAffect.ModifiedNode != nil && nodeAffect.ModifiedNode.LedgerEntryType == AMMROOT:
+			ammParsed, ok := nodeAffect.ModifiedNode.FinalFields.(*AMM)
+			if ok {
+				if nodeAffect.ModifiedNode.LedgerIndex != nil {
+					ammParsed.LedgerIndex = nodeAffect.ModifiedNode.LedgerIndex
+				}
+				return ammParsed, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("AMM not found")
+}

--- a/data/balance.go
+++ b/data/balance.go
@@ -32,10 +32,11 @@ type Balance struct {
 	Balance      Value
 	Change       Value
 	Currency     Currency
+	AMMID        *Hash256
 }
 
 func (b Balance) String() string {
-	return fmt.Sprintf("CounterParty: %-34s  Currency: %s Balance: %20s Change: %20s", b.CounterParty, b.Currency, b.Balance, b.Change)
+	return fmt.Sprintf("CounterParty: %-34s  Currency: %s Balance: %20s Change: %20s AMMID: %v", b.CounterParty, b.Currency, b.Balance, b.Change, b.AMMID)
 }
 
 type BalanceSlice []Balance
@@ -53,22 +54,27 @@ func (s BalanceSlice) Less(i, j int) bool {
 	}
 }
 
-func (s *BalanceSlice) Add(counterparty *Account, balance, change *Value, currency *Currency) {
-	*s = append(*s, Balance{*counterparty, *balance, *change, *currency})
+func (s *BalanceSlice) Add(counterparty *Account, balance, change *Value, currency *Currency, AMMID *Hash256) {
+	if change == nil || currency == nil {
+		return
+	}
+	*s = append(*s, Balance{*counterparty, *balance, *change, *currency, AMMID})
 }
 
 type BalanceMap map[Account]*BalanceSlice
 
-func (m *BalanceMap) Add(account *Account, counterparty *Account, balance, change *Value, currency *Currency) {
+func (m *BalanceMap) Add(account *Account, counterparty *Account, balance, change *Value, currency *Currency, AMMID *Hash256) {
 	_, ok := (*m)[*account]
 	if !ok {
 		(*m)[*account] = &BalanceSlice{}
 	}
-	(*m)[*account].Add(counterparty, balance, change, currency)
+	(*m)[*account].Add(counterparty, balance, change, currency, AMMID)
 }
 
+var txBalanceAcceptedMap = map[TransactionType]bool{OFFER_CREATE: true, PAYMENT: true, AMM_DEPOSIT: true, AMM_WITHDRAW: true, AMM_CREATE: true}
+
 func (txm *TransactionWithMetaData) Balances() (BalanceMap, error) {
-	if txm.GetTransactionType() != OFFER_CREATE && txm.GetTransactionType() != PAYMENT {
+	if !txBalanceAcceptedMap[txm.GetTransactionType()] {
 		return nil, nil
 	}
 	balanceMap := BalanceMap{}
@@ -79,19 +85,48 @@ func (txm *TransactionWithMetaData) Balances() (BalanceMap, error) {
 			switch node.CreatedNode.LedgerEntryType {
 			case ACCOUNT_ROOT:
 				created := node.CreatedNode.NewFields.(*AccountRoot)
-				balanceMap.Add(created.Account, &zeroAccount, &zeroNative, created.Balance, &zeroCurrency)
+				balanceMap.Add(created.Account, &zeroAccount, created.Balance, created.Balance, &zeroCurrency, created.AMMID)
 			case RIPPLE_STATE:
 				// New trust line
 				state := node.CreatedNode.NewFields.(*RippleState)
-				balanceMap.Add(&state.LowLimit.Issuer, &state.HighLimit.Issuer, state.Balance.Value, state.Balance.Value, &state.Balance.Currency)
-				balanceMap.Add(&state.HighLimit.Issuer, &state.LowLimit.Issuer, state.Balance.Value.Negate(), state.Balance.Value.Negate(), &state.Balance.Currency)
+				balanceMap.Add(&state.LowLimit.Issuer, &state.HighLimit.Issuer, state.Balance.Value, state.Balance.Value, &state.Balance.Currency, nil)
+				balanceMap.Add(&state.HighLimit.Issuer, &state.LowLimit.Issuer, state.Balance.Value.Negate(), state.Balance.Value.Negate(), &state.Balance.Currency, nil)
+			case AMMROOT:
+				state := node.CreatedNode.NewFields.(*AMM)
+				balanceMap.Add(&state.LPTokenBalance.Issuer,
+					&state.LPTokenBalance.Issuer,
+					state.LPTokenBalance.Value,
+					state.LPTokenBalance.Value,
+					&state.LPTokenBalance.Currency,
+					nil)
+
 			}
 		case node.DeletedNode != nil:
 			switch node.DeletedNode.LedgerEntryType {
 			case RIPPLE_STATE:
-				//?
+				// A deletion (complete termination of a token) can lead to having to use
+				// the deleted node to determine the balance of the counterparty.
+				var previous, current *RippleState
+				if node.DeletedNode.PreviousFields == nil || node.DeletedNode.FinalFields == nil {
+					continue
+				}
+				previous = node.DeletedNode.PreviousFields.(*RippleState)
+				current = node.DeletedNode.FinalFields.(*RippleState)
+
+				if previous.Balance == nil {
+					//flag change
+					continue
+				}
+				change, err := current.Balance.Subtract(previous.Balance)
+				if err != nil {
+					return nil, err
+				}
+				balanceMap.Add(&current.LowLimit.Issuer, &current.HighLimit.Issuer, current.Balance.Value, change.Value, &current.Balance.Currency, nil)
+				balanceMap.Add(&current.HighLimit.Issuer, &current.LowLimit.Issuer, current.Balance.Value.Negate(), change.Value.Negate(), &current.Balance.Currency, nil)
 			case ACCOUNT_ROOT:
 				return nil, fmt.Errorf("Deleted AccountRoot!")
+			case AMMROOT:
+				// 20230911, NvN: Looks like it is not required to handle this case
 			}
 		case node.ModifiedNode != nil:
 			if node.ModifiedNode.PreviousFields == nil {
@@ -121,7 +156,7 @@ func (txm *TransactionWithMetaData) Balances() (BalanceMap, error) {
 					}
 				}
 				if change.num != 0 {
-					balanceMap.Add(current.Account, &zeroAccount, current.Balance, change.Value, &zeroCurrency)
+					balanceMap.Add(current.Account, &zeroAccount, current.Balance, change.Value, &zeroCurrency, current.AMMID)
 				}
 			case RIPPLE_STATE:
 				// Changed non-native balance
@@ -137,8 +172,23 @@ func (txm *TransactionWithMetaData) Balances() (BalanceMap, error) {
 				if err != nil {
 					return nil, err
 				}
-				balanceMap.Add(&current.LowLimit.Issuer, &current.HighLimit.Issuer, current.Balance.Value, change.Value, &current.Balance.Currency)
-				balanceMap.Add(&current.HighLimit.Issuer, &current.LowLimit.Issuer, current.Balance.Value.Negate(), change.Value.Negate(), &current.Balance.Currency)
+				balanceMap.Add(&current.LowLimit.Issuer, &current.HighLimit.Issuer, current.Balance.Value, change.Value, &current.Balance.Currency, nil)
+				balanceMap.Add(&current.HighLimit.Issuer, &current.LowLimit.Issuer, current.Balance.Value.Negate(), change.Value.Negate(), &current.Balance.Currency, nil)
+			case AMMROOT:
+				// Used to retrieve the currency & issuer for lptokens while parsing balances
+				var (
+					previous = node.ModifiedNode.PreviousFields.(*AMM)
+					current  = node.ModifiedNode.FinalFields.(*AMM)
+				)
+				if previous.LPTokenBalance == nil {
+					//Vote change, bid slot change
+					continue
+				}
+				change, err := current.LPTokenBalance.Subtract(previous.LPTokenBalance)
+				if err != nil {
+					return nil, err
+				}
+				balanceMap.Add(&current.LPTokenBalance.Issuer, &current.LPTokenBalance.Issuer, current.LPTokenBalance.Value, change.Value, &current.LPTokenBalance.Currency, nil)
 			}
 		}
 	}

--- a/data/factory.go
+++ b/data/factory.go
@@ -24,6 +24,7 @@ const (
 	NEGATIVE_UNL     LedgerEntryType = 0x4e // 'N'
 	NFTOKEN_PAGE     LedgerEntryType = 0x50 // 'P'
 	NFTOKEN_OFFER    LedgerEntryType = 0x37 // '7'
+	AMMROOT          LedgerEntryType = 0x41 // 'A'
 
 	// TransactionType values come from rippled's "TxFormats.h"
 	PAYMENT              TransactionType = 0
@@ -50,6 +51,11 @@ const (
 	NFTOKEN_CREATE_OFFER TransactionType = 27
 	NFTOKEN_CANCEL_OFFER TransactionType = 28
 	NFTOKEN_ACCEPT_OFFER TransactionType = 29
+	AMM_CREATE           TransactionType = 35
+	AMM_DEPOSIT          TransactionType = 36
+	AMM_WITHDRAW         TransactionType = 37
+	AMM_VOTE             TransactionType = 38
+	AMM_BID              TransactionType = 39
 
 	AMENDMENT  TransactionType = 100
 	SET_FEE    TransactionType = 101
@@ -77,6 +83,7 @@ var LedgerEntryFactory = [...]func() LedgerEntry{
 	NEGATIVE_UNL:     func() LedgerEntry { return &NegativeUNL{leBase: leBase{LedgerEntryType: NEGATIVE_UNL}} },
 	NFTOKEN_PAGE:     func() LedgerEntry { return &NFTokenPage{leBase: leBase{LedgerEntryType: NFTOKEN_PAGE}} },
 	NFTOKEN_OFFER:    func() LedgerEntry { return &NFTokenOffer{leBase: leBase{LedgerEntryType: NFTOKEN_OFFER}} },
+	AMMROOT:          func() LedgerEntry { return &AMM{leBase: leBase{LedgerEntryType: AMMROOT}} },
 }
 
 var TxFactory = [...]func() Transaction{
@@ -107,6 +114,11 @@ var TxFactory = [...]func() Transaction{
 	NFTOKEN_CREATE_OFFER: func() Transaction { return &NFTokenCreateOffer{TxBase: TxBase{TransactionType: NFTOKEN_CREATE_OFFER}} },
 	NFTOKEN_CANCEL_OFFER: func() Transaction { return &NFTCancelOffer{TxBase: TxBase{TransactionType: NFTOKEN_CANCEL_OFFER}} },
 	NFTOKEN_ACCEPT_OFFER: func() Transaction { return &NFTAcceptOffer{TxBase: TxBase{TransactionType: NFTOKEN_ACCEPT_OFFER}} },
+	AMM_CREATE:           func() Transaction { return &AMMCreate{TxBase: TxBase{TransactionType: AMM_CREATE}} },
+	AMM_DEPOSIT:          func() Transaction { return &AMMDeposit{TxBase: TxBase{TransactionType: AMM_DEPOSIT}} },
+	AMM_WITHDRAW:         func() Transaction { return &AMMWithdraw{TxBase: TxBase{TransactionType: AMM_WITHDRAW}} },
+	AMM_VOTE:             func() Transaction { return &AMMVote{TxBase: TxBase{TransactionType: AMM_VOTE}} },
+	AMM_BID:              func() Transaction { return &AMMBid{TxBase: TxBase{TransactionType: AMM_BID}} },
 }
 
 var ledgerEntryNames = [...]string{
@@ -126,6 +138,7 @@ var ledgerEntryNames = [...]string{
 	NEGATIVE_UNL:     "NegativeUNL",
 	NFTOKEN_PAGE:     "NFTokenPage",
 	NFTOKEN_OFFER:    "NFTokenOffer",
+	AMMROOT:          "AMM",
 }
 
 var ledgerEntryTypes = map[string]LedgerEntryType{
@@ -145,6 +158,7 @@ var ledgerEntryTypes = map[string]LedgerEntryType{
 	"NegativeUNL":    NEGATIVE_UNL,
 	"NFTokenPage":    NFTOKEN_PAGE,
 	"NFTokenOffer":   NFTOKEN_OFFER,
+	"AMM":            AMMROOT,
 }
 
 var txNames = [...]string{
@@ -175,6 +189,11 @@ var txNames = [...]string{
 	NFTOKEN_CREATE_OFFER: "NFTokenCreateOffer",
 	NFTOKEN_CANCEL_OFFER: "NFTokenCancelOffer",
 	NFTOKEN_ACCEPT_OFFER: "NFTokenAcceptOffer",
+	AMM_CREATE:           "AMMCreate",
+	AMM_DEPOSIT:          "AMMDeposit",
+	AMM_WITHDRAW:         "AMMWithdraw",
+	AMM_VOTE:             "AMMVote",
+	AMM_BID:              "AMMBid",
 }
 
 var txTypes = map[string]TransactionType{
@@ -205,6 +224,11 @@ var txTypes = map[string]TransactionType{
 	"NFTokenCreateOffer":   NFTOKEN_CREATE_OFFER,
 	"NFTokenCancelOffer":   NFTOKEN_CANCEL_OFFER,
 	"NFTokenAcceptOffer":   NFTOKEN_ACCEPT_OFFER,
+	"AMMCreate":            AMM_CREATE,
+	"AMMDeposit":           AMM_DEPOSIT,
+	"AMMWithdraw":          AMM_WITHDRAW,
+	"AMMVote":              AMM_VOTE,
+	"AMMBid":               AMM_BID,
 }
 
 var HashableTypes []string

--- a/data/flags.go
+++ b/data/flags.go
@@ -54,6 +54,17 @@ const (
 	// PaymentChannelClaim flags
 	TxRenew TransactionFlag = 0x00010000
 	TxClose TransactionFlag = 0x00020000
+
+	// AMM flags
+	// Deposit & withdraw
+	TfLPToken             TransactionFlag = 0x00010000
+	TfSingleAsset         TransactionFlag = 0x00080000
+	TfTwoAsset            TransactionFlag = 0x00100000
+	TfOneAssetLPToken     TransactionFlag = 0x00200000
+	TfLimitLPToken        TransactionFlag = 0x00400000
+	TfTwoAssetIfEmpty     TransactionFlag = 0x00800000
+	TfWithdrawAll         TransactionFlag = 0x00020000
+	TfOneAssetWithdrawAll TransactionFlag = 0x00040000
 )
 
 // Ledger entry flags
@@ -118,6 +129,23 @@ var txFlagNames = map[TransactionType][]struct {
 		{TxClearNoRipple, "ClearNoRipple"},
 		{TxSetFreeze, "SetFreeze"},
 		{TxClearFreeze, "ClearFreeze"},
+	},
+	AMM_DEPOSIT: {
+		{TfLPToken, "LPToken"},
+		{TfSingleAsset, "SingleAsset"},
+		{TfTwoAsset, "TwoAsset"},
+		{TfOneAssetLPToken, "OneAssetLPToken"},
+		{TfLimitLPToken, "LimitLPToken"},
+		{TfTwoAssetIfEmpty, "TwoAssetIfEmpty"},
+	},
+	AMM_WITHDRAW: {
+		{TfLPToken, "LPToken"},
+		{TfWithdrawAll, "WithdrawAll"},
+		{TfOneAssetWithdrawAll, "OneAssetWithdrawAll"},
+		{TfSingleAsset, "SingleAsset"},
+		{TfTwoAsset, "TwoAsset"},
+		{TfOneAssetLPToken, "OneAssetLPToken"},
+		{TfLimitLPToken, "LimitLPToken"},
 	},
 }
 

--- a/data/ledgerentry.go
+++ b/data/ledgerentry.go
@@ -31,6 +31,7 @@ type AccountRoot struct {
 	NFTokenMinter  *Account         `json:",omitempty"`
 	MintedNFTokens *uint32          `json:",omitempty"`
 	BurnedNFTokens *uint32          `json:",omitempty"`
+	AMMID          *Hash256         `json:",omitempty"`
 }
 
 type RippleState struct {
@@ -219,6 +220,31 @@ type NFTokenOffer struct {
 	Destination      *Account         `json:",omitempty"`
 	Expiration       *uint32          `json:",omitempty"`
 }
+type VoteEntry struct {
+	Account    Account `json:",omitempty"`
+	TradingFee uint32  `json:",omitempty"`
+	VoteWeight uint32  `json:",omitempty"`
+}
+
+type AuctionSlot struct {
+	Account       Account `json:",omitempty"`
+	DiscountedFee uint32  `json:",omitempty"`
+	Expiration    *uint32 `json:",omitempty"`
+	Price         Amount  `json:",omitempty"`
+}
+
+type AMM struct {
+	leBase
+	Flags          *LedgerEntryFlag `json:",omitempty"`
+	Asset          Asset            `json:",omitempty"`
+	Asset2         Asset            `json:",omitempty"`
+	Account        *Account         `json:",omitempty"`
+	LPTokenBalance *Amount          `json:",omitempty"`
+	TradingFee     uint32           `json:",omitempty"`
+	VoteSlots      []VoteEntry      `json:",omitempty"`
+	AuctionSlot    *AuctionSlot     `json:",omitempty"`
+	LedgerIndex    *Hash256         `json:",omitempty"`
+}
 
 func (a *AccountRoot) Affects(account Account) bool {
 	return a.Account != nil && a.Account.Equals(account)
@@ -263,6 +289,8 @@ func (to *NFTokenOffer) Affects(account Account) bool {
 	return (to.Owner != nil && to.Owner.Equals(account)) || (to.Destination != nil && to.Destination.Equals(account))
 }
 
+func (p *AMM) Affects(account Account) bool { return p.Account != nil }
+
 func (le *leBase) GetType() string                     { return ledgerEntryNames[le.LedgerEntryType] }
 func (le *leBase) GetLedgerEntryType() LedgerEntryType { return le.LedgerEntryType }
 func (le *leBase) Prefix() HashPrefix                  { return HP_LEAF_NODE }
@@ -275,4 +303,8 @@ func (le *leBase) GetPreviousTxnId() *Hash256          { return le.PreviousTxnID
 
 func (o *Offer) Ratio() *Value {
 	return o.TakerPays.Ratio(*o.TakerGets)
+}
+
+func (a *AMM) AMMID() *Hash256 {
+	return a.LedgerIndex
 }

--- a/data/result.go
+++ b/data/result.go
@@ -11,6 +11,7 @@ const (
 	// - Forwarded
 	tesSUCCESS TransactionResult = 0
 )
+
 const (
 	// 100 .. 159 C Claim fee only (ripple transaction with no good paths, pay to non-existent account, no path)
 	// Causes:
@@ -29,6 +30,7 @@ const (
 	tecUNFUNDED_PAYMENT
 	tecFAILED_PROCESSING
 )
+
 const (
 	tecDIR_FULL TransactionResult = iota + 121
 	tecINSUF_RESERVE_LINE
@@ -71,6 +73,13 @@ const (
 	tecINSUFFICIENT_FUNDS
 	tecOBJECT_NOT_FOUND
 	tecINSUFFICIENT_PAYMENT
+	tecAMM_UNFUNDED
+	tecAMM_BALANCE
+	tecAMM_FAILED                           // Questionable: ripple-binary-codec/dist/enums/src/enums/definitions.json has 2 tecAMM_FAILED codes
+	tecAMM_INVALID_TOKENS TransactionResult = iota + 164
+	tecAMM_EMPTY                            // ripple-binary-codec/dist/enums/src/enums/definitions.json does not have this code
+	tecAMM_NOT_EMPTY                        // ripple-binary-codec/dist/enums/src/enums/definitions.json does not have this code
+	tecAMM_ACCOUNT                          // ripple-binary-codec/dist/enums/src/enums/definitions.json does not have this code
 )
 
 const (
@@ -94,6 +103,7 @@ const (
 	telCAN_NOT_QUEUE_FEE
 	telCAN_NOT_QUEUE_FULL
 )
+
 const (
 	// -299 .. -200: M Malformed (bad signature)
 	// Causes:
@@ -139,7 +149,9 @@ const (
 	temUNKNOWN
 	temSEQ_AND_TICKET
 	temBAD_NFTOKEN_TRANSFER_FEE
+	temBAD_AMM_TOKENS // ripple-binary-codec/dist/enums/src/enums/definitions.json has this as temAMM_BAD_TOKENS
 )
+
 const (
 	// -199 .. -100: F Failure (sequence number previously used)
 	// Causes:
@@ -177,6 +189,7 @@ const (
 	tefNO_TICKET
 	tefNFTOKEN_IS_NOT_TRANSFERABLE
 )
+
 const (
 	// -99 .. -1: R Retry (sequence too high, no funds for txn fee, originating account non-existent)
 	// Causes:
@@ -198,6 +211,10 @@ const (
 	terLAST                          // Process after all other transactions
 	terNO_RIPPLE                     // Rippling not allowed
 	terQUEUED                        // Transaction is being held in TxQ until fee drops
+)
+
+const (
+	terNO_AMM TransactionResult = iota - 87 // No AMM for this asset pair
 )
 
 var resultNames = map[TransactionResult]struct {
@@ -251,6 +268,14 @@ var resultNames = map[TransactionResult]struct {
 	tecINSUFFICIENT_FUNDS:            {"tecINSUFFICIENT_FUNDS", "Not enough funds available to complete requested transaction."},
 	tecOBJECT_NOT_FOUND:              {"tecOBJECT_NOT_FOUND", "A requested object could not be located."},
 	tecINSUFFICIENT_PAYMENT:          {"tecINSUFFICIENT_PAYMENT", "The payment is not sufficient."},
+
+	tecAMM_UNFUNDED:       {"tecAMM_UNFUNDED", "AMM creation failed: User has insufficient funds."},
+	tecAMM_BALANCE:        {"tecAMM_BALANCE", "The AMM or the user has insufficient balance."},
+	tecAMM_FAILED:         {"tecAMM_FAILED", "The AMM failed to execute the trade."},
+	tecAMM_INVALID_TOKENS: {"tecAMM_INVALID_TOKENS", "Insufficient LPTokens or problem with rounding."},
+	tecAMM_EMPTY:          {"tecAMM_EMPTY", "AMM has no assets in its pool."},
+	tecAMM_NOT_EMPTY:      {"tecAMM_NOT_EMPTY", "The AMM has assets in its pool."},
+	tecAMM_ACCOUNT:        {"tecAMM_ACCOUNT", "The operation is not allowed on AMM accounts."},
 
 	tefFAILURE:                     {"tefFAILURE", "Failed to apply."},
 	tefALREADY:                     {"tefALREADY", "The exact transaction was already in this ledger."},
@@ -325,6 +350,7 @@ var resultNames = map[TransactionResult]struct {
 	temSEQ_AND_TICKET:           {"temSEQ_AND_TICKET", "Transaction contains a TicketSequence and a non-zero Sequence"},
 	temBAD_NFTOKEN_TRANSFER_FEE: {"temBAD_NFTOKEN_TRANSFER_FEE", "Malformed: The NFToken transfer fee must be between 1 and 5000, inclusive."},
 	temBAD_WEIGHT:               {"temBAD_WEIGHT", "The SignerListSet transaction includes a SignerWeight that is invalid, for example a zero or negative value."},
+	temBAD_AMM_TOKENS:           {"temBAD_AMM_TOKENS", "Incorrect assets specified"},
 
 	terRETRY:       {"terRETRY", "Retry transaction."},
 	terFUNDS_SPENT: {"terFUNDS_SPENT", "Can't set password, password set funds already spent."},
@@ -337,6 +363,7 @@ var resultNames = map[TransactionResult]struct {
 	terPRE_SEQ:     {"terPRE_SEQ", "Missing/inapplicable prior transaction."},
 	terOWNERS:      {"terOWNERS", "Non-zero owner count."},
 	terQUEUED:      {"terQUEUED", "Held until escalated fee drops."},
+	terNO_AMM:      {"terNO_AMM", "No AMM for this asset pair."},
 }
 
 var reverseResults map[string]TransactionResult

--- a/data/transaction.go
+++ b/data/transaction.go
@@ -255,6 +255,53 @@ type NFTAcceptOffer struct {
 	TicketSequence   *uint32  `json:",omitempty"`
 }
 
+type AMMCreate struct {
+	TxBase
+	Amount     Amount `json:",omitempty"`
+	Amount2    Amount `json:",omitempty"`
+	TradingFee uint16 `json:",omitempty"` // Between 0 and 1000 (0 and 1%)
+}
+
+type AMMDeposit struct {
+	TxBase
+	Amount     *Amount `json:",omitempty"`
+	Amount2    *Amount `json:",omitempty"`
+	Asset      Asset   `json:",omitempty"`
+	Asset2     Asset   `json:",omitempty"`
+	EPrice     *Amount `json:",omitempty"`
+	LPTokenOut *Amount `json:",omitempty"`
+}
+
+type AMMWithdraw struct {
+	TxBase
+	Amount    *Amount `json:",omitempty"`
+	Amount2   *Amount `json:",omitempty"`
+	Asset     Asset   `json:",omitempty"`
+	Asset2    Asset   `json:",omitempty"`
+	EPrice    *Amount `json:",omitempty"`
+	LPTokenIn *Amount `json:",omitempty"`
+}
+
+type AMMVote struct {
+	TxBase
+	Asset      Asset  `json:",omitempty"`
+	Asset2     Asset  `json:",omitempty"`
+	TradingFee uint16 `json:",omitempty"` // Between 0 and 1000 (0 and 1%)
+}
+
+type AuthAccounts struct {
+	Account Account `json:",omitempty"`
+}
+
+type AMMBid struct {
+	TxBase
+	Asset        Asset          `json:",omitempty"`
+	Asset2       Asset          `json:",omitempty"`
+	BidMin       *Amount        `json:",omitempty"`
+	BidMax       *Amount        `json:",omitempty"`
+	AuthAccounts []AuthAccounts `json:",omitempty"`
+}
+
 func (t *TxBase) GetBase() *TxBase                    { return t }
 func (t *TxBase) GetType() string                     { return txNames[t.TransactionType] }
 func (t *TxBase) GetTransactionType() TransactionType { return t.TransactionType }

--- a/websockets/commands.go
+++ b/websockets/commands.go
@@ -261,6 +261,38 @@ type AccountOffersResult struct {
 	Offers         data.AccountOfferSlice `json:"offers"`
 }
 
+type AMMInfoCommand struct {
+	*Command
+	Asset  data.Asset     `json:"asset"`
+	Asset2 data.Asset     `json:"asset2"`
+	Result *AMMInfoResult `json:"result,omitempty"`
+}
+
+type AMMInfoResult struct {
+	LedgerSequence uint32 `json:"ledger_current_index"`
+	AMMData        struct {
+		Amount       *data.Amount `json:",omitempty"`
+		Amount2      *data.Amount `json:",omitempty"`
+		AssetFrozen  bool         `json:"asset_frozen,omitempty"`
+		Asset2Frozen bool         `json:"asset2_frozen,omitempty"`
+		AuctionSlot  struct {
+			Account       data.Account `json:",omitempty"`
+			DiscountedFee uint32       `json:"discounted_fee,omitempty"`
+			Expiration    string       `json:",omitempty"`
+			Price         data.Amount  `json:",omitempty"`
+			TimeInterval  uint32       `json:"time_interval,omitempty"`
+		} `json:"auction_slot,omitempty"`
+		Account        *data.Account `json:",omitempty"`
+		LPTokenBalance *data.Amount  `json:"lp_token,omitempty"`
+		TradingFee     uint32        `json:"trading_fee,omitempty"`
+		VoteSlots      []struct {
+			Account    data.Account `json:",omitempty"`
+			TradingFee uint32       `json:"trading_fee,omitempty"`
+			VoteWeight uint32       `json:"vote_weight,omitempty"`
+		} `json:"vote_slots,omitempty"`
+	} `json:"amm"`
+}
+
 type BookOffersCommand struct {
 	*Command
 	LedgerIndex interface{}  `json:"ledger_index,omitempty"`

--- a/websockets/remote.go
+++ b/websockets/remote.go
@@ -598,3 +598,20 @@ func dump(b []byte) string {
 	out, _ := json.MarshalIndent(v, "", "  ")
 	return string(out)
 }
+
+func (r *Remote) AMMInfo(asset data.Asset, asset2 data.Asset) (*AMMInfoResult, error) {
+	cmd := &AMMInfoCommand{
+		Command: newCommand("amm_info"),
+		Asset:   asset,
+		Asset2:  asset2,
+	}
+	r.outgoing <- cmd
+	<-cmd.Ready
+	if cmd.CommandError != nil {
+		return nil, cmd.CommandError
+	}
+	if cmd.Result == nil {
+		return nil, fmt.Errorf("missing AMM info")
+	}
+	return cmd.Result, nil
+}


### PR DESCRIPTION
Full AMM implementation.

The AMMID has been added to the account root object as AMMID. Based on this the choice was made to extend the balance functionalities with the AMMID.

The parsing of the balances for the AMM revealed (from my perspective) issues with the balance parsing in the account root where a new account root would have zero balance, while in reality it actually has a balance of X (whatever the initial deposit is).
The balance parsing implementation has been extended to determine the balance using a deleted node: Divesting from an AMM pool leads to having to use the deleted node for determining the balance.

In the AMM (Root) the AMMID is the LedgerIndex, leading to the helper function to get the AMMID in a consistent fashion.

